### PR TITLE
Set Rs default library path to ~/R

### DIFF
--- a/Renviron
+++ b/Renviron
@@ -1,0 +1,1 @@
+R_LIBS_USER="~/R"


### PR DESCRIPTION
Note you'll have to ensure `~/R` exists before it can be used. 